### PR TITLE
Fix: Assignment to constant variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function _spawn(mvn, args) {
 *     Defines to be passed to the mvn executable via "-D" flags.
 */
 function _run(mvn, commands, defines) {
-  const args = [];
+  var args = [];
   if (mvn.options.settings) {
     args.push('-s', mvn.options.settings);
   }


### PR DESCRIPTION
Make variable `args` non-const for allowing later assignment.
