### PR TITLE
Allow using ./mvnw wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ The following options can be passed to the <code>create</code> method:
 #### `cwd` (default: ```process.cwd()```)
 This parameter can be used to define the working directory when invoking the Maven command line.
 
+#### `cmd` (default: ```mvn``` (or ```mvn.bat``` on Windows))
+Maven executable relative to `cwd`. If your project uses the maven wrapper, consider `'cmd': './mvnw'`; otherwise, if you use your system-level installation of `maven`, you likely don't need to change this.
+
 #### `file` (default: ```undefined```)
 Can be used to pass a specific POM file to the Maven command line. If nothing is specified, the Maven process itself will look for a file called ```pom.xml``` in the base directory.
 

--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ const isWin = /^win/.test(process.platform);
 */
 function _spawn(mvn, args) {
   const spawn = require('child_process').spawn;
-  // Command to be executed. 'mvn' or 'mvn.bat' when using Windows.
-  let cmd = 'mvn';
+  // Command to be executed.
+  let cmd = mvn.options.cmd || 'mvn';
   return new Promise((resolve, reject) => {
     if (isWin) {
       args.unshift(cmd);
@@ -117,6 +117,9 @@ function _run(mvn, commands, defines) {
  * @typedef {Object} MavenOptions
  * @property {(string|undefined)} cwd
  *   Working directory (Default is: <code>process.cwd()</code>)
+ * @property {{string|undefined}} cmd
+ *   Maven executable relative to <code>cwd</code>. Default is 'mvn' or 
+ *   'mvn.bat' when using Windows.
  * @property {(string|undefined)} file
  *   Filename of the POM. (Results in <code>-f ${file}</code>)
  * @property {(string|undefined)} settings

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -20,6 +20,8 @@
 type MavenOptions = {
     /** Working directory (Default is: <code>process.cwd()</code>) */
     cwd?: string,
+    /** Maven executable relative to <code>cwd</code>. Default is 'mvn' or 'mvn.bat' when using Windows */
+    cmd?: string,
     /** Filename of the POM. (Results in <code>-f ${file}</code>) */
     file?: string,
     /** Filename of settings.xml to be used (Results in <code>-s ${setings}</code>) */


### PR DESCRIPTION
I don't have maven installed on my system. I wanted to use my project's maven wrapper. This allows you to specify the maven binary executable to use relative to `cwd`. Example:

```javascript
const maven = require('maven').create({
  cwd: '/project/path/here/',
  cmd: './mvnw'
})
```