### PR TITLE
./mvnw by default if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The following options can be passed to the <code>create</code> method:
 #### `cwd` (default: ```process.cwd()```)
 This parameter can be used to define the working directory when invoking the Maven command line.
 
-#### `cmd` (default: ```mvn``` (or ```mvn.bat``` on Windows))
-Maven executable relative to `cwd`. If your project uses the maven wrapper, consider `'cmd': './mvnw'`; otherwise, if you use your system-level installation of `maven`, you likely don't need to change this.
+#### `cmd` (default: ```./mvnw``` if in project root, otherwise ```mvn``` (or ```mvn.bat``` on Windows))
+Maven executable relative to `cwd`. For example, `cwd: '/usr/local/bin/mvn`
 
 #### `file` (default: ```undefined```)
 Can be used to pass a specific POM file to the Maven command line. If nothing is specified, the Maven process itself will look for a file called ```pom.xml``` in the base directory.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following options can be passed to the <code>create</code> method:
 #### `cwd` (default: ```process.cwd()```)
 This parameter can be used to define the working directory when invoking the Maven command line.
 
-#### `cmd` (default: ```./mvnw``` if in project root, otherwise ```mvn``` (or ```mvn.bat``` on Windows))
+#### `cmd` (default: ```./mvnw``` if present in project root, otherwise ```mvn``` (or ```mvn.bat``` on Windows))
 Maven executable relative to `cwd`. For example, `cwd: '/usr/local/bin/mvn`
 
 #### `file` (default: ```undefined```)

--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@
 const isWin = /^win/.test(process.platform);
 
 /**
+ * Determine if maven wrapper (./mvnw) is present in cwd root
+ */
+const mvnw = cwd => require('fs').existsSync(require('path').join(cwd, 'mvnw')) ? './mvnw' : false
+
+/**
 * A simple wrapper around child_process.spawn that returns a promise.
 * @private
 * @param {!Maven} mvn
@@ -39,7 +44,7 @@ const isWin = /^win/.test(process.platform);
 function _spawn(mvn, args) {
   const spawn = require('child_process').spawn;
   // Command to be executed.
-  let cmd = mvn.options.cmd || 'mvn';
+  let cmd = mvn.options.cmd || mvnw(mvn.options.cwd) || 'mvn';
   return new Promise((resolve, reject) => {
     if (isWin) {
       args.unshift(cmd);
@@ -118,8 +123,8 @@ function _run(mvn, commands, defines) {
  * @property {(string|undefined)} cwd
  *   Working directory (Default is: <code>process.cwd()</code>)
  * @property {{string|undefined}} cmd
- *   Maven executable relative to <code>cwd</code>. Default is 'mvn' or 
- *   'mvn.bat' when using Windows.
+ *   Maven executable relative to <code>cwd</code>. Default is './mvnw' if the mvnw 
+ *   executable is in your project root. Otherwise, default is 'mvn' or 'mvn.bat' when using Windows.
  * @property {(string|undefined)} file
  *   Filename of the POM. (Results in <code>-f ${file}</code>)
  * @property {(string|undefined)} settings

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -20,7 +20,8 @@
 type MavenOptions = {
     /** Working directory (Default is: <code>process.cwd()</code>) */
     cwd?: string,
-    /** Maven executable relative to <code>cwd</code>. Default is 'mvn' or 'mvn.bat' when using Windows */
+    /** Maven executable relative to <code>cwd</code>. Default is './mvnw' if the mvnw executable is in your project root. 
+     * Otherwise, default is 'mvn' or 'mvn.bat' when using Windows. */
     cmd?: string,
     /** Filename of the POM. (Results in <code>-f ${file}</code>) */
     file?: string,


### PR DESCRIPTION
Unfortunately I haven't tested this on a Windows system. If someone could make sure this works on a Windows box, that'd be nice.

If you'd like to test this & need a project which uses the mvnw wrapper, you can create a quick project on https://start.spring.io/ From the command line, you'd run `./mvnw install spring-boot:run`

Also don't mind the split usernames. I made this commit on my work computer, so it's using 'Aaron Gershman' instead of 'aegershman'. I can fix this if it's an issue.