### PR TITLE
Use platform-specific path syntax when inferring mvnw location

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ const isWin = /^win/.test(process.platform);
 /**
  * Determine if maven wrapper (./mvnw) is present in cwd root
  */
-const mvnw = cwd => require('fs').existsSync(require('path').join(cwd, 'mvnw')) ? './mvnw' : false
+const mvnw = cwd => {
+    const cmd = require("path").resolve(cwd, "mvnw");
+    return require("fs").existsSync(cmd) ? cmd : false;
+};
 
 /**
 * A simple wrapper around child_process.spawn that returns a promise.


### PR DESCRIPTION
Invoking cmd.exe with ./mvnw does not end well. Instead, keep the
platform-specific resolved path and use that for the executable.