### PR TITLE
typings: improve typings

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -71,8 +71,9 @@ interface Maven {
      *     List of defines that will be passed to the Java VM via
      *     <code>-Dkey=value</code>
      */
-    execute(commands, defines): Promise<any>;
+    execute(commands: string | string[], defines?: { [name: string]: string }): Promise<void>;
 
 }
 
-export default Maven;
+declare const maven: Maven
+export default maven;


### PR DESCRIPTION
Add types to execute, and change the Promise return type to void as nothing is returned on success.

Export a constant of type Maven so that it can be used as per the example.